### PR TITLE
Escaping whitespace characters in script file paths, removing redundant log file creations and moving shared function imports

### DIFF
--- a/functions/Install-DbaReports.ps1
+++ b/functions/Install-DbaReports.ps1
@@ -523,7 +523,7 @@
       else
       {
         #$JobFilePath = [regex]::Escape($InstallPath)
-        $JobFilePath = $InstallPath
+        $JobFilePath = $InstallPath.Replace(" ", "`` ")
         $JobCommand = "powershell.exe -ExecutionPolicy Bypass . "
       }
 			

--- a/setup/powershell/AgentJobDetail.ps1
+++ b/setup/powershell/AgentJobDetail.ps1
@@ -27,12 +27,16 @@ Param (
 
 BEGIN
 {
+	# Load up shared functions
+	$currentdir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+	. "$currentdir\shared.ps1"
+	. "$currentdir\Write-Log.ps1"
+	
 	# Create Log File 
 	$Date = Get-Date -Format yyyyMMdd_HHmmss
 	$LogFilePath = $LogFileFolder + '\' + 'dbareports_AgentJobDetail_' + $Date + '.txt'
 	try
 	{
-		New-item -Path $LogFilePath -itemtype File -ErrorAction Stop 
 		Write-Log -path $LogFilePath -message "Agent Job Detail Job started" -level info
 	}
 	catch
@@ -44,11 +48,6 @@ BEGIN
 	$table = "info.AgentJobDetail"
 	$schema = $table.Split(".")[0]
 	$tablename = $table.Split(".")[1]
-	
-	# Load up shared functions
-	$currentdir = Split-Path -Parent $MyInvocation.MyCommand.Definition
-	. "$currentdir\shared.ps1"
-	. "$currentdir\Write-Log.ps1"
 	
 	# Connect to dbareports server
 	try

--- a/setup/powershell/AgentJobServer.ps1
+++ b/setup/powershell/AgentJobServer.ps1
@@ -29,12 +29,16 @@ Param (
 
 BEGIN
 {
-		# Create Log File 
+	# Load up shared functions
+	$currentdir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+	. "$currentdir\shared.ps1"
+	. "$currentdir\Write-Log.ps1"
+	
+	# Create Log File 
 	$Date = Get-Date -Format yyyyMMdd_HHmmss
 	$LogFilePath = $LogFileFolder + '\' + 'dbareports_AgentJobServer_' + $Date + '.txt'
 	try
 	{
-		New-item -Path $LogFilePath -itemtype File -ErrorAction Stop 
 		Write-Log -path $LogFilePath -message "Agent Job Server Job started" -level info
 	}
 	catch
@@ -47,12 +51,7 @@ BEGIN
 	$schema = $table.Split(".")[0]
 	$tablename = $table.Split(".")[1]
 	
-	# Load up shared functions
-	$currentdir = Split-Path -Parent $MyInvocation.MyCommand.Definition
-	. "$currentdir\shared.ps1"
-	. "$currentdir\Write-Log.ps1"
-	
-		# Connect to dbareports server
+	# Connect to dbareports server
 	try
 	{
 		Write-Log -path $LogFilePath -message "Connecting to $sqlserver" -level info

--- a/setup/powershell/Alerts.ps1
+++ b/setup/powershell/Alerts.ps1
@@ -36,7 +36,6 @@ BEGIN
 	$LogFilePath = $LogFileFolder + '\' + 'dbareports_Alerts_' + $Date + '.txt'
 	try
 	{
-		New-item -Path $LogFilePath -itemtype File -ErrorAction Stop 
 		Write-Log -path $LogFilePath -message "Alerts Job started" -level info
 	}
 	catch

--- a/setup/powershell/Databases.ps1
+++ b/setup/powershell/Databases.ps1
@@ -36,7 +36,6 @@ BEGIN
 	$LogFilePath = $LogFileFolder + '\' + 'dbareports_Databases_' + $Date + '.txt'
 	try
 	{
-		New-item -Path $LogFilePath -itemtype File -ErrorAction Stop 
 		Write-Log -path $LogFilePath -message "Databases Job started" -level info
 	}
 	catch

--- a/setup/powershell/DiskSpace.ps1
+++ b/setup/powershell/DiskSpace.ps1
@@ -37,7 +37,6 @@ BEGIN
 	$LogFilePath = $LogFileFolder + '\' + 'dbareports_DiskSpace_' + $Date + '.txt'
 	try
 	{
-		New-item -Path $LogFilePath -itemtype File -ErrorAction Stop 
 		Write-Log -path $LogFilePath -message "DiskSpace Job started" -level info
 	}
 	catch

--- a/setup/powershell/LogFileErrorMessages.ps1
+++ b/setup/powershell/LogFileErrorMessages.ps1
@@ -36,7 +36,6 @@ BEGIN
 	$LogFilePath = $LogFileFolder + '\' + 'dbareports_LogFileErrorMessages_' + $Date + '.txt'
 	try
 	{
-		New-item -Path $LogFilePath -itemtype File -ErrorAction Stop 
 		Write-Log -path $LogFilePath -message "Databases Job started" -level info
 	}
 	catch

--- a/setup/powershell/SQLInfo.ps1
+++ b/setup/powershell/SQLInfo.ps1
@@ -38,7 +38,6 @@ BEGIN
 	$LogFilePath = $LogFileFolder + '\' + 'dbareports_SQLInfo_' + $Date + '.txt'
 	try
 	{
-		New-item -Path $LogFilePath -itemtype File -ErrorAction Stop 
 		Write-Log -path $LogFilePath -message "SQLInfo Job started" -level info
 	}
 	catch

--- a/setup/powershell/ServerOSInfo.ps1
+++ b/setup/powershell/ServerOSInfo.ps1
@@ -50,7 +50,6 @@ BEGIN
 	$LogFilePath = $LogFileFolder + '\' + 'dbareports_ServerOSInfo_' + $Date + '.txt'
 	try
 	{
-		New-item -Path $LogFilePath -itemtype File -ErrorAction Stop 
 		Write-Log -path $LogFilePath -message "ServerOSInfo Job started" -level info
 	}
 	catch

--- a/setup/powershell/SuspectPages.ps1
+++ b/setup/powershell/SuspectPages.ps1
@@ -36,7 +36,6 @@ BEGIN
 	$LogFilePath = $LogFileFolder + '\' + 'dbareports_SuspectPages_' + $Date + '.txt'
 	try
 	{
-		New-item -Path $LogFilePath -itemtype File -ErrorAction Stop 
 		Write-Log -path $LogFilePath -message "SuspectPages Job started" -level info
 	}
 	catch


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
 - Escaping whitespace characters in script file paths
 - Removing redundant log file creations as they cause errors
 - Moving shared function imports to the beginning of some scripts to avoid errors.

How to test this code:
 - Install dbareports. Run the SQL Agent jobs and make sure the step output looks as desired.

Has been tested on (remove any that don't apply):
 - SQL Server 2016
