### PR TITLE
Adding InstanceName to SELECT to support named instances.

### DIFF
--- a/setup/database/Tables/info.DiskSpace.sql
+++ b/setup/database/Tables/info.DiskSpace.sql
@@ -14,3 +14,9 @@ ALTER TABLE [info].[DiskSpace] ADD CONSTRAINT [PK_DiskSpace_1] PRIMARY KEY CLUST
 GO
 ALTER TABLE [info].[DiskSpace] ADD CONSTRAINT [FK_DiskSpace_ServerInfo] FOREIGN KEY ([ServerID]) REFERENCES [info].[ServerInfo] ([ServerID])
 GO
+CREATE UNIQUE NONCLUSTERED INDEX [UIX_DiskSpace_ServerID_DiskName] ON [info].[DiskSpace]
+(
+	[ServerID] ASC,
+	[DiskName] ASC
+)
+GO

--- a/setup/powershell/DiskSpace.ps1
+++ b/setup/powershell/DiskSpace.ps1
@@ -144,8 +144,8 @@ PROCESS
 			$diskname = $disk.name
 			if (!$diskname.StartsWith("\\"))
 			{
-				$update = $false
-				$row = $table | Where-Object { $_.DiskName -eq $DiskName -and $_.ServerId -eq $ServerId}
+				$update = $true
+				$row = $table | Where-Object { $_.DiskName -eq $DiskName -and $_.ServerId -eq $ServerId} | Sort-Object -Property Date | Select-Object -First 1
 				$key = $row.DiskSpaceID
 				
 				if ($key.count -eq 0)
@@ -163,7 +163,7 @@ PROCESS
 					$Null = $datatable.Rows.Add(
 					$key,
 					$Date,
-					$ServerId ,
+					$ServerId,
 					$diskname,
 					$disk.Label,
 					$total,
@@ -178,9 +178,9 @@ PROCESS
 					Write-Log -path $LogFilePath -message "Failed to add Job to datatable - $_" -level Error
 					Write-Log -path $LogFilePath -message "Data = $key,
 					$Date,
-					$ServerId ,
+					$ServerId,
 					$diskname,
-					$disk.Label,
+					$($disk.Label),
 					$total,
 					$free,
 					$percentfree,

--- a/setup/powershell/ServerOSInfo.ps1
+++ b/setup/powershell/ServerOSInfo.ps1
@@ -92,7 +92,7 @@ PROCESS
 	try
 	{
 		Write-Log -path $LogFilePath -message "Getting a list of servers from the dbareports database" -level info
-		$sql = "SELECT DISTINCT ServerID, ServerName FROM dbo.instancelist"
+		$sql = "SELECT DISTINCT ServerID, ServerName, InstanceName FROM dbo.instancelist"
 		$sqlservers = $sourceserver.Databases[$InstallDatabase].ExecuteWithResults($sql).Tables[0]
 		Write-Log -path $LogFilePath -message "Got the list of servers from the dbareports database" -level info
 	


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
 - Adding "InstanceName" to SELECT statement to support windows discovery on named instances.

How to test this code:
 - Install DbaReports. 
 - Add at least one named instance to the inventory. 
 - Run the job "dbareports - Windows Server Information". 
 - Check job history for errors and make sure that the server information gets updated properly in the table "info.ServerInfo" 

Has been tested on (remove any that don't apply):
 - SQL Server 2016
