### PR TITLE
Fixing updates and preventing duplicates

### DIFF
--- a/setup/database/Tables/info.DiskSpace.sql
+++ b/setup/database/Tables/info.DiskSpace.sql
@@ -14,3 +14,9 @@ ALTER TABLE [info].[DiskSpace] ADD CONSTRAINT [PK_DiskSpace_1] PRIMARY KEY CLUST
 GO
 ALTER TABLE [info].[DiskSpace] ADD CONSTRAINT [FK_DiskSpace_ServerInfo] FOREIGN KEY ([ServerID]) REFERENCES [info].[ServerInfo] ([ServerID])
 GO
+CREATE UNIQUE NONCLUSTERED INDEX [UIX_DiskSpace_ServerID_DiskName] ON [info].[DiskSpace]
+(
+	[ServerID] ASC,
+	[DiskName] ASC
+)
+GO

--- a/setup/powershell/DiskSpace.ps1
+++ b/setup/powershell/DiskSpace.ps1
@@ -144,8 +144,8 @@ PROCESS
 			$diskname = $disk.name
 			if (!$diskname.StartsWith("\\"))
 			{
-				$update = $false
-				$row = $table | Where-Object { $_.DiskName -eq $DiskName -and $_.ServerId -eq $ServerId}
+				$update = $true
+				$row = $table | Where-Object { $_.DiskName -eq $DiskName -and $_.ServerId -eq $ServerId} | Sort-Object -Property Date | Select-Object -First 1
 				$key = $row.DiskSpaceID
 				
 				if ($key.count -eq 0)
@@ -163,7 +163,7 @@ PROCESS
 					$Null = $datatable.Rows.Add(
 					$key,
 					$Date,
-					$ServerId ,
+					$ServerId,
 					$diskname,
 					$disk.Label,
 					$total,
@@ -178,9 +178,9 @@ PROCESS
 					Write-Log -path $LogFilePath -message "Failed to add Job to datatable - $_" -level Error
 					Write-Log -path $LogFilePath -message "Data = $key,
 					$Date,
-					$ServerId ,
+					$ServerId,
 					$diskname,
-					$disk.Label,
+					$($disk.Label),
 					$total,
 					$free,
 					$percentfree,


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
Fixing issue where duplicate entries for disks where added to the table info.DiskSpace when running the disk space monitoring script by: 
- Adding a unique index index when the table info.DiskSpace is created. 
- Adding logic to the monitoring script to avoid issues with existing duplicates and to prevent creating new duplicates. 
- Changes the "update" variable to be "true" as initial value. 
- Fixing error output for disk label. 

How to test this code:
 - Update existing dbareports installation or create a new installation and run the monitoring scripts at least three times.
- Check the table info.DiskSpace for duplicates and check the log for errors.
 

Has been tested on (remove any that don't apply):
 - SQL Server 2014
 - SQL Server 2016
