### PR TITLE
Update shared.ps1  function Initialize-Datatable

### DIFF
--- a/setup/powershell/Shared.ps1
+++ b/setup/powershell/Shared.ps1
@@ -521,6 +521,11 @@ foreach ($result in $results.Tables.rows)
         {
             $Column = New-Object system.Data.DataColumn $ColumnName, ([float]) 
             Write-Output "Added $ColumnName of float"
+        }
+	 elseif($result.data_type -eq 'decimal')
+        {
+            $Column = New-Object system.Data.DataColumn $ColumnName, ([decimal]) 
+            Write-Output "Added $ColumnName of float"
         } 
        else 
        { 


### PR DESCRIPTION
Added datatype decimal to the function to avoid error when running job dbareports - Disk Usage
Error from pshell logging is: ERROR: Bulk insert failed - Exception calling "ExecuteNonQuery" with "0" argument(s): "Error converting data type nvarchar to numeric.
The data for table-valued parameter "@TVP" doesn't conform to the table type of the parameter. SQL Server error is: 8114, state: 5
The statement has been terminated." 

In the background a conversion error (nvarchar to numeric) is thrown

Fixes # .

Changes proposed in this pull request:
 - 
 - 
 - 

How to test this code:
 - 
 - 
 - 

Has been tested on (remove any that don't apply):
 - Case-sensitive SQL Server instance
 - SQL Server 2008
 - SQL Server 2008 R2
 - SQL Server 2012
 - SQL Server 2014
 - SQL Server 2016
 - Amazon RDS
 - Azure SQL DB
